### PR TITLE
ci: Fix pre-commit errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
       - id: check-merge-conflict
       - id: check-symlinks
       - id: check-yaml
+        args: ["--unsafe"] # Required because of line 57 in mkdocs.yml which enables mermaid diagrams
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
@@ -68,10 +69,10 @@ repos:
         additional_dependencies:
           - tomli; python_version<'3.11'
 
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.11.0.1"
-    hooks:
-      - id: shellcheck
+  # - repo: https://github.com/shellcheck-py/shellcheck-py
+  #   rev: "v0.11.0.1"
+  #   hooks:
+  #     - id: shellcheck
 
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,9 +171,16 @@ exclude = [  # don't report on objects that match any of these regex
     "^test_",
     "^conftest",
     "^conf$",
+    "noxfile*"
 ]
 override_SS05 = [  # override SS05 to allow docstrings starting with these words
     "^Process ",
     "^Assess ",
     "^Access ",
 ]
+
+[tool.codespell]
+skip = '*.spm*,*.mplstyle,*.svg,*.stp,*.top,*.002,*.004,uv.lock'
+count = ''
+quiet-level = 3
+ignore-words-list = 'OT'


### PR DESCRIPTION
Closes #10

- Disable [shellcheck](https://www.shellcheck.net) for now, no plans to write any shell scripts for this project.
- [numpydoc-validation](https://numpydoc.readthedocs.io/en/latest/validation.html) ignore `noxfile.py` not our file.
- [codespell](https://github.com/codespell-project/codespell) ignore AFM images and `uv.lock`