### PR TITLE
test(run_modules): Add tests to repository; chore: tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ Thumbs.db
 # Other directories to exclude
 orig/
 tmp/
+output/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,26 +66,12 @@ repos:
         args: ["--fix", "--show-fixes", "--exit-non-zero-on-fix"]
       - id: ruff-format
 
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: "v1.19.1"
-  #   hooks:
-  #     - id: mypy
-  #       files: src|tests
-  #       args: []
-  #       additional_dependencies:
-  #         - pytest
-
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.4.2"
     hooks:
       - id: codespell
         additional_dependencies:
           - tomli; python_version<'3.11'
-
-  # - repo: https://github.com/shellcheck-py/shellcheck-py
-  #   rev: "v0.11.0.1"
-  #   hooks:
-  #     - id: shellcheck
 
   - repo: local
     hooks:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pkgutil import get_data
 from typing import Any
 
+import matplotlib as mpl
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -26,6 +27,15 @@ RESOURCES_SPM = RESOURCES / "spm"
 
 
 # pylint: disable=too-many-lines
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_matplotlib():
+    """
+    Force ``matplotlib`` to use the non-interactive ``Agg`` backend to prevent Tcl/Tk threading errors during
+    tests.
+    """
+    mpl.use("Agg")
 
 
 @pytest.fixture(name="default_config")

--- a/tests/test_run_modules.py
+++ b/tests/test_run_modules.py
@@ -1,0 +1,119 @@
+"""Test run_modules module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from afmslicer import entry_point
+
+BASE_DIR = Path.cwd()
+RESOURCES = BASE_DIR / "tests" / "resources"
+SPM_DIR = RESOURCES / "spm"
+
+# NB - Tests are not performed directly on the `run_modules.*()` functions but via the entry_point which runs these.
+
+
+@pytest.mark.parametrize(
+    ("manually_provided_arguments"),
+    [
+        pytest.param(
+            [
+                "--config",
+                f"{BASE_DIR / 'src' / 'afmslicer' / 'default_config.yaml'}",
+                "--base-dir",
+                "./tests/resources/spm",
+                "--file-ext",
+                ".spm",
+                "filter",
+            ],
+            id="basic filter",
+        ),
+    ],
+)
+def test_filter(
+    manually_provided_arguments: list[str],
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Test for run_modules.filter()."""
+    entry_point.entry_point(manually_provided_arguments)
+    captured = capsys.readouterr()
+    assert "~~~~~~~~~~~~~~~~~~~~ COMPLETE ~~~~~~~~~~~~~~~~~~~~" in captured.err
+    assert "Successfully Processed^1    : 2 (100.0%)" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("manually_provided_arguments"),
+    [
+        pytest.param(
+            [
+                "--config",
+                f"{BASE_DIR / 'src' / 'afmslicer' / 'default_config.yaml'}",
+                "--base-dir",
+                "./tests/resources/spm",
+                "--file-ext",
+                ".spm",
+                "slicer",
+                "--slices",  # ns-rse 2026-02-18 Need to update TopoStats to update dictionaries with
+                "5",  #                   as these do not go into the config
+            ],
+            id="basic slicer",
+        ),
+    ],
+)
+def test_slicer(
+    manually_provided_arguments: list[str],
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Test for run_modules.filter()."""
+    entry_point.entry_point(manually_provided_arguments)
+    captured = capsys.readouterr()
+    assert "~~~~~~~~~~~~~~~~~~~~ COMPLETE ~~~~~~~~~~~~~~~~~~~~" in captured.err
+    assert "Successfully Processed^1    : 2 (100.0%)" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("manually_provided_arguments"),
+    [
+        pytest.param(
+            [
+                "--config",
+                f"{BASE_DIR / 'src' / 'afmslicer' / 'default_config.yaml'}",
+                "--base-dir",
+                "./tests/resources/spm",
+                "--file-ext",
+                ".spm",
+                "process",
+                "--slices",
+                "5",
+            ],
+            id="basic process",
+        ),
+    ],
+)
+def test_process(
+    manually_provided_arguments: list[str],
+    capsys: pytest.CaptureFixture,
+    tmp_path: Path,
+    snapshot,
+) -> None:
+    """Test for run_modules.filter()."""
+    # prepend the output directory as tmp_path
+    manually_provided_arguments = [
+        "-o",
+        f"{tmp_path}",
+        *manually_provided_arguments,
+    ]
+    entry_point.entry_point(manually_provided_arguments)
+    captured = capsys.readouterr()
+    assert "~~~~~~~~~~~~~~~~~~~~ COMPLETE ~~~~~~~~~~~~~~~~~~~~" in captured.err
+    assert "Successfully Processed^1    : 2 (100.0%)" in captured.err
+    assert Path(tmp_path / "all_statistics.csv").is_file()
+    assert Path(tmp_path / "color_count.csv").is_file()
+    # Loads the results and check against a Syrupy snapshot
+    all_statistics_df = pd.read_csv(tmp_path / "all_statistics.csv")
+    assert all_statistics_df.to_string() == snapshot
+    color_count_df = pd.read_csv(tmp_path / "color_count.csv")
+    assert color_count_df.to_string() == snapshot


### PR DESCRIPTION
Add missing `tests/test_run_modules.py` which actually checks the `afmslicer.run_modules` module works indirectly by
running/simulating using the function at the command line.

Also..

- Removes unused hooks from `.pre-commit-config.yaml`
- Adds `output/` to `.gitignore`