### PR TITLE
ci: install --group dev in gh workflows

### DIFF
--- a/.github/workflows/build_mkdocs.yaml
+++ b/.github/workflows/build_mkdocs.yaml
@@ -21,11 +21,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - name: Install and setup uv with python
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: 3.11
       - run: |
-          pip install .[docs]
+          uv pip install --python=3.11 pip
+      - run: |
+          uv pip install -e . --group dev
       - run: mkdocs gh-deploy --config-file mkdocs.yml --force
 
   deploy_mkdocs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,7 @@ jobs:
           pip show pip setuptools
           virtualenv --upgrade-embed-wheels
           # virtualenv --reset-app-data
-          pip install -e .[tests]
+          pip install -e . --group dev
       - name: Test with pytest
         run: |
           pytest --cov=src --numprocesses=logical


### PR DESCRIPTION
Having moved to `[dependency-groups]` in `pyproject.toml` we can no longer install `pip install -e .[dev]` instead we must use `pip install -e . --group dev` to install the `dev` group of dependencies (which includes `tests` and `docs`).

Also switch to using `uv` [github action](https://github.com/astral-sh/setup-uv) to setup Python in the `build_mkdocs.yaml` workflow.