### PR TITLE
ci: setup uv venv before attempting to use

### DIFF
--- a/.github/workflows/build_mkdocs.yaml
+++ b/.github/workflows/build_mkdocs.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: 3.11
       - run: |
-          uv pip install --python=3.11 pip
+          uv venv --python 3.11
       - name: Install package with dev dependencies
         run: |
           uv pip install -e . --group dev


### PR DESCRIPTION
Received the following error message...

```
Run uv pip install --python=3.11 pip
  uv pip install --python=3.11 pip
  shell: /usr/bin/bash -e {0}
  env:
    UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
    UV_PYTHON: 3.11
    UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
error: No virtual environment found for Python 3.11; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
Error: Process completed with exit code 2.
```

...after following the [example](https://github.com/astral-sh/setup-uv#python-version) in the docs...

```
- name: Install the latest version of uv and set the python version to 3.13t
  uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
  with:
    python-version: 3.13t
- run: uv pip install --python=3.13t pip
```