### PR TITLE
fix(run_modules): explicitly sort dataframes before writing to csv

### DIFF
--- a/src/afmslicer/run_modules.py
+++ b/src/afmslicer/run_modules.py
@@ -199,11 +199,13 @@ def process(args: argparse.Namespace | None = None) -> None:
         pore_colors=config["slicing"]["pore_colors"],
         area_val="area",
     )
+    statistics_all_df = statistics_all_df.sort_values(by=["image", "layer", "pore"])
     statistics_all_df.to_csv(config["output_dir"] / "all_statistics.csv", index=False)
     # Aggregate counts by image, layer and pore color, reshape and sum
     color_count_df = statistics.summarise_pores(
         df=statistics_all_df, pore_colors=config["slicing"]["pore_colors"]
     )
+    color_count_df = color_count_df.sort_values(by=["image", "layer"])
     color_count_df.to_csv(config["output_dir"] / "color_count.csv", index=False)
     # Write config to file
     write_yaml(config, output_dir=config["output_dir"], header_message=HEADER_MESSAGE)


### PR DESCRIPTION
Sort the two CSV outputs by...

- `all_statistics.csv` : `image` `layer` and `pore`
- `color_count.csv` : `image` and `layer`

Closes #110